### PR TITLE
Fixes #15

### DIFF
--- a/lib/asciidoctor-multipage.rb
+++ b/lib/asciidoctor-multipage.rb
@@ -52,6 +52,14 @@ class Asciidoctor::Document
   # nodes are no longer accessible.
   attr_writer :sectnum
 
+  # A pointer to the original converter (first converter instantiated to
+  # convert the original document). As we create additional documents
+  # ourselves, AsciiDoctor will instantiate additional instances of
+  # MultipageHtml5Converter for each created document. These instances need
+  # to share state, so they can use the original converter instance
+  # for that purpose.
+  attr_accessor :mp_root
+
   # Override the AbstractBlock sections?() check to enable the Table Of
   # Contents. This extension may generate short pages that would normally have
   # no need for a TOC. However, we override the Html5Converter outline() in
@@ -101,6 +109,12 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
 
   attr_accessor :pages
 
+  # contains the entire outline of the top-level document, used
+  # as a guide-rail for creating TOC elements for documents we
+  # split off. Only expected to be set in the top-level converter
+  # (see AsciiDoctor::Document::mp_root)
+  attr_accessor :full_outline
+
   def initialize(backend, opts = {})
     @xml_mode = false
     @void_element_slash = nil
@@ -118,8 +132,29 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
     page << block
   end
 
+  # ensures that the AsciiDoctor::Document::mp_root is correctly
+  # set on the document object. The variable could have already been
+  # set if we created the document ourselves
+  # (see ::MultipageHtml5Converter::convert_section), in which case it's
+  # not changed. If the documented is "nested", then we expect the parent
+  # document to already have it set. Otherwise, this is expected to be
+  # a top-level document, and we assign ourselves as its original converter.
+  def check_root(doc)
+    unless doc.mp_root
+      if doc.nested?
+        doc.mp_root = doc.parent_document.mp_root
+      else
+        doc.mp_root = self
+      end
+    end
+  end
+
   # Process Document (either the original full document or a processed page)
   def convert_document(node)
+
+    # make sure document has original converter reference
+    check_root(node)
+
     if node.processed
       # This node (an individual page) can now be handled by
       # Html5Converter.
@@ -167,7 +202,16 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
       generate_nav_links(node)
 
       # Create and save a skeleton document for generating the TOC lists.
-      @@full_outline = new_outline_doc(node)
+
+      # don't attempt to create outline for nested documents.
+      unless node.nested?
+        # if the original converter has the @full_outline set already, we are about
+        # to replace it. That's not supposed to happen, and probably means we encountered
+        # a document structure we aren't prepared for. Log an error and move on.
+        logger.error "Regenerating document outline, something wrong?" if node.mp_root.full_outline
+        node.mp_root.full_outline = new_outline_doc(node)
+      end
+
       # Save the document catalog to use for each part/chapter page.
       @catalog = node.catalog
 
@@ -179,7 +223,7 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
           part = block
           part.convert
           text = %(<<#{part.id},#{part.captioned_title}>>)
-          if desc = block.attr('desc') then text << %( – #{desc}) end
+          if (desc = block.attr('desc')) then text << %( – #{desc}) end
           parts_list << Asciidoctor::ListItem.new(parts_list, text)
         end
       end
@@ -197,6 +241,8 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
   # Process Document in embeddable mode (either the original full document or a
   # processed page)
   def convert_embedded(node)
+    # make sure document has original converter reference
+    check_root(node)
     if node.processed
       # This node (an individual page) can now be handled by
       # Html5Converter.
@@ -350,7 +396,7 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
   end
 
   # From node, create a skeleton document that will be used to generate the
-  # TOC. This is first used to create a full skeleton (@@full_outline) from the
+  # TOC. This is first used to create a full skeleton (@full_outline) from the
   # original document (for_page=nil). Then it is used for each individual page
   # to create a second skeleton from the first. In this way, TOC entries are
   # included that are not part of the current page, or excluded if not
@@ -392,10 +438,10 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
   # outline.
   def convert_outline(node, opts = {})
     doc = node.document
-    # Find this node in the @@full_outline skeleton document
-    page_node = @@full_outline.find_by(id: node.id).first
+    # Find this node in the @full_outline skeleton document
+    page_node = doc.mp_root.full_outline.find_by(id: node.id).first
     # Create a skeleton document for this particular page
-    custom_outline_doc = new_outline_doc(@@full_outline, for_page: page_node)
+    custom_outline_doc = new_outline_doc(doc.mp_root.full_outline, for_page: page_node)
     opts[:page_id] = node.id
     # Generate an extra TOC entry for the root page. Add additional styling if
     # the current page is the root page.
@@ -454,6 +500,8 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
       if node.parent.respond_to?(:numbered) && node.parent.numbered
         page.sectnum = node.parent.sectnum
       end
+
+      page.mp_root = doc.mp_root
 
       # Process node according to mplevel
       if node.mplevel == :branch

--- a/test/black-box-docs/consistent-toc/_document_1.html
+++ b/test/black-box-docs/consistent-toc/_document_1.html
@@ -1,0 +1,24 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<p><span class="toc-root"><a href="consistent-toc.html">TOP</a></span></p><ul class="sectlevel1">
+<li><a href="_domain_1.html">Domain 1</a>
+<ul class="sectlevel2">
+<li><a href="_document_1.html"><span class="toc-current">Document 1</span></a>
+</li>
+<li><a href="_document_2.html">Document 2</a>
+</li>
+</ul>
+</li>
+<li><a href="_domain_2.html">Domain 2</a>
+</li>
+</ul>
+</div>
+<div class="sect2">
+<h3 id="_document_1">Document 1</h3>
+<div class="paragraph">
+<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
+</div>
+</div>
+<div class="paragraph nav-footer">
+<p>↑ Up: <a href="_domain_1.html">Domain 1</a> | ⌂ Home: <a href="consistent-toc.html">TOP</a> | Next: <a href="_document_2.html">Document 2</a> →</p>
+</div>

--- a/test/black-box-docs/consistent-toc/_document_1_2.html
+++ b/test/black-box-docs/consistent-toc/_document_1_2.html
@@ -1,0 +1,24 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<p><span class="toc-root"><a href="consistent-toc.html">TOP</a></span></p><ul class="sectlevel1">
+<li><a href="_domain_1.html">Domain 1</a>
+</li>
+<li><a href="_domain_2.html">Domain 2</a>
+<ul class="sectlevel2">
+<li><a href="_document_1_2.html"><span class="toc-current">Document 1</span></a>
+</li>
+<li><a href="_document_2_2.html">Document 2</a>
+</li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="sect2">
+<h3 id="_document_1_2">Document 1</h3>
+<div class="paragraph">
+<p>Contrary to popular belief, Lorem Ipsum is not simply random text.</p>
+</div>
+</div>
+<div class="paragraph nav-footer">
+<p>↑ Up: <a href="_domain_2.html">Domain 2</a> | ⌂ Home: <a href="consistent-toc.html">TOP</a> | Next: <a href="_document_2_2.html">Document 2</a> →</p>
+</div>

--- a/test/black-box-docs/consistent-toc/_document_2.html
+++ b/test/black-box-docs/consistent-toc/_document_2.html
@@ -1,0 +1,50 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<p><span class="toc-root"><a href="consistent-toc.html">TOP</a></span></p><ul class="sectlevel1">
+<li><a href="_domain_1.html">Domain 1</a>
+<ul class="sectlevel2">
+<li><a href="_document_1.html">Document 1</a>
+</li>
+<li><a href="_document_2.html"><span class="toc-current">Document 2</span></a>
+</li>
+</ul>
+</li>
+<li><a href="_domain_2.html">Domain 2</a>
+</li>
+</ul>
+</div>
+<div class="sect2">
+<h3 id="_document_2">Document 2</h3>
+<div class="paragraph">
+<p>It is a long established fact that a reader will be distracted by the
+readable content of a page when looking at its layout.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">good doc</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
+<ul>
+<li>
+<p>bad doc</p>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<ul>
+</ul>
+</div>
+<div class="paragraph nav-footer">
+<p></p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="paragraph nav-footer">
+<p>← Previous: <a href="_document_1.html">Document 1</a> | ↑ Up: <a href="_domain_1.html">Domain 1</a> | ⌂ Home: <a href="consistent-toc.html">TOP</a> | Next: <a href="_domain_2.html">Domain 2</a> →</p>
+</div>

--- a/test/black-box-docs/consistent-toc/_document_2_2.html
+++ b/test/black-box-docs/consistent-toc/_document_2_2.html
@@ -1,0 +1,25 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<p><span class="toc-root"><a href="consistent-toc.html">TOP</a></span></p><ul class="sectlevel1">
+<li><a href="_domain_1.html">Domain 1</a>
+</li>
+<li><a href="_domain_2.html">Domain 2</a>
+<ul class="sectlevel2">
+<li><a href="_document_1_2.html">Document 1</a>
+</li>
+<li><a href="_document_2_2.html"><span class="toc-current">Document 2</span></a>
+</li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="sect2">
+<h3 id="_document_2_2">Document 2</h3>
+<div class="paragraph">
+<p>There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form,
+by injected humour, or randomised words which don&#8217;t look even slightly believable.</p>
+</div>
+</div>
+<div class="paragraph nav-footer">
+<p>← Previous: <a href="_document_1_2.html">Document 1</a> | ↑ Up: <a href="_domain_2.html">Domain 2</a> | ⌂ Home: <a href="consistent-toc.html">TOP</a></p>
+</div>

--- a/test/black-box-docs/consistent-toc/_domain_1.html
+++ b/test/black-box-docs/consistent-toc/_domain_1.html
@@ -1,0 +1,33 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<p><span class="toc-root"><a href="consistent-toc.html">TOP</a></span></p><ul class="sectlevel1">
+<li><a href="_domain_1.html"><span class="toc-current">Domain 1</span></a>
+<ul class="sectlevel2">
+<li><a href="_document_1.html">Document 1</a>
+</li>
+<li><a href="_document_2.html">Document 2</a>
+</li>
+</ul>
+</li>
+<li><a href="_domain_2.html">Domain 2</a>
+</li>
+</ul>
+</div>
+<div class="sect1">
+<h2 id="_domain_1">Domain 1</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="_document_1.html">Document 1</a></p>
+</li>
+<li>
+<p><a href="_document_2.html">Document 2</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="paragraph nav-footer">
+<p>↑ Up: <a href="consistent-toc.html">TOP</a> | Next: <a href="_document_1.html">Document 1</a> →</p>
+</div>

--- a/test/black-box-docs/consistent-toc/_domain_2.html
+++ b/test/black-box-docs/consistent-toc/_domain_2.html
@@ -1,0 +1,33 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<p><span class="toc-root"><a href="consistent-toc.html">TOP</a></span></p><ul class="sectlevel1">
+<li><a href="_domain_1.html">Domain 1</a>
+</li>
+<li><a href="_domain_2.html"><span class="toc-current">Domain 2</span></a>
+<ul class="sectlevel2">
+<li><a href="_document_1_2.html">Document 1</a>
+</li>
+<li><a href="_document_2_2.html">Document 2</a>
+</li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="sect1">
+<h2 id="_domain_2">Domain 2</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="_document_1_2.html">Document 1</a></p>
+</li>
+<li>
+<p><a href="_document_2_2.html">Document 2</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="paragraph nav-footer">
+<p>← Previous: <a href="_document_2.html">Document 2</a> | ↑ Up: <a href="consistent-toc.html">TOP</a> | Next: <a href="_document_1_2.html">Document 1</a> →</p>
+</div>

--- a/test/black-box-docs/consistent-toc/consistent-toc.adoc
+++ b/test/black-box-docs/consistent-toc/consistent-toc.adoc
@@ -1,0 +1,31 @@
+= TOP
+:toc:
+:multipage-level: 2
+
+== Domain 1
+
+=== Document 1
+
+Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+
+=== Document 2
+
+It is a long established fact that a reader will be distracted by the
+readable content of a page when looking at its layout.
+
+[cols=","]
+|===
+|good doc a|
+* bad doc
+|===
+
+== Domain 2
+
+=== Document 1
+
+Contrary to popular belief, Lorem Ipsum is not simply random text.
+
+=== Document 2
+
+There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form,
+by injected humour, or randomised words which don't look even slightly believable.

--- a/test/black-box-docs/consistent-toc/consistent-toc.html
+++ b/test/black-box-docs/consistent-toc/consistent-toc.html
@@ -1,0 +1,22 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<p><span class="toc-root toc-current"><a href="consistent-toc.html">TOP</a></span></p><ul class="sectlevel1">
+<li><a href="_domain_1.html">Domain 1</a>
+</li>
+<li><a href="_domain_2.html">Domain 2</a>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="_domain_1.html">Domain 1</a></p>
+</li>
+<li>
+<p><a href="_domain_2.html">Domain 2</a></p>
+</li>
+</ul>
+</div>
+<div class="paragraph nav-footer">
+<p>Next: <a href="_domain_1.html">Domain 1</a> →</p>
+</div>

--- a/test/black-box-docs/table-block-operator/_second.html
+++ b/test/black-box-docs/table-block-operator/_second.html
@@ -1,6 +1,13 @@
 <div id="toc" class="toc">
 <div id="toctitle">Table of Contents</div>
-<p><span class="toc-root"><a href="table-block-operator.html">TOP</a></span></p>
+<p><span class="toc-root"><a href="table-block-operator.html">TOP</a></span></p><ul class="sectlevel1">
+<li><a href="_second.html"><span class="toc-current">SECOND</span></a>
+<ul class="sectlevel2">
+<li><a href="_oops.html">OOPS</a>
+</li>
+</ul>
+</li>
+</ul>
 </div>
 <div class="sect1">
 <h2 id="_second">SECOND</h2>


### PR DESCRIPTION
If I prevent `@@full_outline` from being reset in the middle of rendering, the ToC problem is fixed.
However, the tests no longer work because the class variable is no longer changed between classes.

I tried to making it an instance variable, but that causes an NPE at line 396.

Things I don't understand:
* Why is there more than instance of the converter instantiated?
* I assume we can theoretically `remove_class_variable` `@@full_outline`, but at which point? May be when the conversion is done? Since there are apparently multiple converter instances, I don't quite understand when are we "done"

I modded the test code to make it easier to run a single test, or run HTML update by setting an env var, was quite handy.
