### PR TITLE
add asciidoctor-multipage executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,11 @@ $ asciidoctor -V
 Asciidoctor 2.0.11 [https://asciidoctor.org]
 ```
 
-Use Asciidoctor's `-r` option to require `asciidoctor-multipage` and the `-b`
-option to select the `multipage_html5` backend. The following command generates
-HTML output from a sample document; view the output by loading
-`test/out/sample.html` in a browser.
+The following command generates HTML output from a sample document; view the 
+output by loading `test/out/sample.html` in a browser.
 
 ```
-$ asciidoctor -r asciidoctor-multipage -b multipage_html5 \
-    -D test/out test/black-box-docs/sample/sample.adoc
+$ asciidoctor-multipage -D test/out test/black-box-docs/sample/sample.adoc
 ```
 
 ## Adjusting behavior

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ output by loading `test/out/sample.html` in a browser.
 $ asciidoctor-multipage -D test/out test/black-box-docs/sample/sample.adoc
 ```
 
+Alternatively, use Asciidoctor's `--require` option like this:
+
+```
+$ asciidoctor -r asciidoctor-multipage -b multipage_html5 \
+    -D test/out test/black-box-docs/sample/sample.adoc
+```
+
 ## Adjusting behavior
 
 The `multipage-level` and `desc` attributes are the most important for using

--- a/asciidoctor-multipage.gemspec
+++ b/asciidoctor-multipage.gemspec
@@ -4,7 +4,8 @@ require "asciidoctor-multipage/version"
 
 Gem::Specification.new do |s|
   s.authors = ['Owen T. Heisler']
-  s.files = Dir['lib/*.rb']
+  s.executables = ['asciidoctor-multipage']
+  s.files = Dir['bin/*', 'lib/**/*.rb']
   s.name = 'asciidoctor-multipage'
   s.summary = 'Asciidoctor multipage HTML output extension'
   s.version = AsciidoctorMultipage::VERSION

--- a/bin/asciidoctor-multipage
+++ b/bin/asciidoctor-multipage
@@ -1,5 +1,9 @@
 #!/usr/bin/env ruby
 
+# This executable is based on `bin/asciidoctor-pdf` from the
+# asciidoctor/asciidoctor-pdf project. Please consult that file for
+# potential updates.
+
 require 'asciidoctor-multipage'
 require 'asciidoctor-multipage/version'
 require 'asciidoctor/cli'

--- a/bin/asciidoctor-multipage
+++ b/bin/asciidoctor-multipage
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require 'asciidoctor-multipage'
+require 'asciidoctor-multipage/version'
+require 'asciidoctor/cli'
+
+options = Asciidoctor::Cli::Options.new backend: 'multipage_html5'
+
+# FIXME (from asciidoctor-pdf) provide an API in Asciidoctor for sub-components to print version information
+unless ARGV != ['-v'] && (ARGV & ['-V', '--version']).empty?
+  $stdout.write %(Asciidoctor Multipage #{AsciidoctorMultipage::VERSION} using )
+  options.print_version
+  exit 0
+end
+
+# FIXME (from bespoke) This is a really bizarre API. Please make me simpler.
+if Integer === (result = options.parse! ARGV)
+  exit result
+else
+  invoker = Asciidoctor::Cli::Invoker.new options
+  GC.start
+  invoker.invoke!
+  exit invoker.code
+end

--- a/lib/asciidoctor-multipage.rb
+++ b/lib/asciidoctor-multipage.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+require 'asciidoctor'
 require 'asciidoctor/converter/html5'
 
 class Asciidoctor::AbstractBlock


### PR DESCRIPTION
To make this extension easier to use this add an `asciidoctor-multipage` executable, based on `asciidoctor-pdf` and `asciidoctor-reveal.js`.